### PR TITLE
9.0z1: grafana version update from 12.2.0 -> 12.3.1

### DIFF
--- a/.tekton/grafana-9-0-pull-request.yaml
+++ b/.tekton/grafana-9-0-pull-request.yaml
@@ -17,6 +17,9 @@ metadata:
   name: grafana-9-0-on-pull-request
   namespace: ceph-tenant
 spec:
+  timeouts:
+    pipeline: 5h
+    tasks: 5h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -216,6 +219,7 @@ spec:
           value:
           - $(params.build-platforms)
       name: build-images
+      timeout: 5h
       params:
       - name: IMAGE
         value: $(params.output-image)

--- a/.tekton/grafana-9-0-push.yaml
+++ b/.tekton/grafana-9-0-push.yaml
@@ -16,6 +16,9 @@ metadata:
   name: grafana-9-0-on-push
   namespace: ceph-tenant
 spec:
+  timeouts:
+    pipeline: 5h
+    tasks: 5h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -213,6 +216,7 @@ spec:
           value:
           - $(params.build-platforms)
       name: build-images
+      timeout: 5h
       params:
       - name: IMAGE
         value: $(params.output-image)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
 # Build stage 1
 
-ARG BASE_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.24
+ARG BASE_IMAGE=registry.redhat.io/ubi9/go-toolset:latest
 
 FROM ${BASE_IMAGE} AS builder
 
-COPY grafana grafana
+# Grafana tends to use the fodlers from the root directory.
+USER root
 
-WORKDIR grafana
+COPY grafana /grafana
+
+WORKDIR /grafana
 
 ENV GOFLAGS="-mod=vendor"
 
@@ -68,12 +71,11 @@ ENTRYPOINT [ "/run.sh" ]
 # Build specific labels
 LABEL maintainer="Nizamudeen A <nia@redhat.com>"
 LABEL com.redhat.component="grafana-container"
-LABEL version="12.2.0"
-LABEL name="grafana"
+LABEL version="12.3.1"
+LABEL name=rhceph/grafana-rhel9
 LABEL description="Red Hat Ceph Storage Grafana container"
 LABEL summary="Grafana container on RHEL 9 for Red Hat Ceph Storage"
 LABEL io.k8s.display-name="Grafana on RHEL 9"
 LABEL io.k8s.description="grafana-container"
 LABEL io.openshift.tags="rhceph ceph dashboard grafana"
-LABEL cpe=cpe:/a:redhat:ceph_storage:9::el10
-LABEL org.opencontainers.image.created="${BUILD_DATE}"
+LABEL cpe=cpe:/a:redhat:ceph_storage:9::el9

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -4,13 +4,13 @@ lockfileVendor: redhat
 arches:
 - arch: aarch64
   packages:
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/a/audit-libs-4.0.3-1.el10.aarch64.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/a/audit-libs-4.0.3-4.el10.aarch64.rpm
     repoid: rhel-10-for-aarch64-baseos-rpms
-    size: 132507
-    checksum: sha256:bc4ee5ae0c6f85e2577b540c118727e22e320bb78863736b8680d17ef332c1d0
+    size: 134261
+    checksum: sha256:4c8c03549a7f95a7ce0a264bda020eb7d18440c0d682e5a4f1e64b7ce603f3d1
     name: audit-libs
-    evr: 4.0.3-1.el10
-    sourcerpm: audit-4.0.3-1.el10.src.rpm
+    evr: 4.0.3-4.el10
+    sourcerpm: audit-4.0.3-4.el10.src.rpm
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/b/basesystem-11-22.el10.noarch.rpm
     repoid: rhel-10-for-aarch64-baseos-rpms
     size: 8521
@@ -32,41 +32,41 @@ arches:
     name: bzip2-libs
     evr: 1.0.8-25.el10
     sourcerpm: bzip2-1.0.8-25.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/f/filesystem-3.18-16.el10.aarch64.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/f/filesystem-3.18-17.el10.aarch64.rpm
     repoid: rhel-10-for-aarch64-baseos-rpms
-    size: 4979138
-    checksum: sha256:0c98fa57a5d987d6a23c0e5ec38ec18e34ca0e31edb69453950cdf3fc773ece3
+    size: 5009573
+    checksum: sha256:c95d485c8c1b64ff848ead07465353ddeb58d75dfef21454da1f2930c96db43b
     name: filesystem
-    evr: 3.18-16.el10
-    sourcerpm: filesystem-3.18-16.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/g/glibc-2.39-46.el10_0.4.aarch64.rpm
+    evr: 3.18-17.el10
+    sourcerpm: filesystem-3.18-17.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/g/glibc-2.39-58.el10_1.7.aarch64.rpm
     repoid: rhel-10-for-aarch64-baseos-rpms
-    size: 1778728
-    checksum: sha256:e536cf0e41b732b203c7a3d1289de01874a85e4d650d8bbf1794ae2e1809b359
+    size: 1770990
+    checksum: sha256:38021246feca2308b7d04c43d97f8a7cc5ea8e579ebdda3171329247813660ab
     name: glibc
-    evr: 2.39-46.el10_0.4
-    sourcerpm: glibc-2.39-46.el10_0.4.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/g/glibc-common-2.39-46.el10_0.4.aarch64.rpm
+    evr: 2.39-58.el10_1.7
+    sourcerpm: glibc-2.39-58.el10_1.7.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/g/glibc-common-2.39-58.el10_1.7.aarch64.rpm
     repoid: rhel-10-for-aarch64-baseos-rpms
-    size: 332486
-    checksum: sha256:b4a026ce15b11610d873479c92f55a385a05cec0fbb9875f4f61546759bdaf1b
+    size: 319893
+    checksum: sha256:f8e2e7541f67ef63f0c7133b7ea48ae97c3820a82001c0b5bee4e8f3a03071cd
     name: glibc-common
-    evr: 2.39-46.el10_0.4
-    sourcerpm: glibc-2.39-46.el10_0.4.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/g/glibc-gconv-extra-2.39-46.el10_0.4.aarch64.rpm
+    evr: 2.39-58.el10_1.7
+    sourcerpm: glibc-2.39-58.el10_1.7.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/g/glibc-gconv-extra-2.39-58.el10_1.7.aarch64.rpm
     repoid: rhel-10-for-aarch64-baseos-rpms
-    size: 1843363
-    checksum: sha256:257782e336691ac2fac658ade23ce0cceed0c8b9a23326a80d72df4cc83776e7
+    size: 1834484
+    checksum: sha256:5f8a63bf454d9dfbb2c608d411d023a55456c685de321e75850f6358457e8399
     name: glibc-gconv-extra
-    evr: 2.39-46.el10_0.4
-    sourcerpm: glibc-2.39-46.el10_0.4.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/g/glibc-minimal-langpack-2.39-46.el10_0.4.aarch64.rpm
+    evr: 2.39-58.el10_1.7
+    sourcerpm: glibc-2.39-58.el10_1.7.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/g/glibc-minimal-langpack-2.39-58.el10_1.7.aarch64.rpm
     repoid: rhel-10-for-aarch64-baseos-rpms
-    size: 43953
-    checksum: sha256:1d08aa807e9b83ab796eaae2c86d5a14ac93c845c592b2ea72df6a09a1aaa79f
+    size: 31833
+    checksum: sha256:70fa3faa27f47756ce0f46411f7ea53b3645405412c21da345e229e3182c073f
     name: glibc-minimal-langpack
-    evr: 2.39-46.el10_0.4
-    sourcerpm: glibc-2.39-46.el10_0.4.src.rpm
+    evr: 2.39-58.el10_1.7
+    sourcerpm: glibc-2.39-58.el10_1.7.src.rpm
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/l/libacl-2.3.2-4.el10.aarch64.rpm
     repoid: rhel-10-for-aarch64-baseos-rpms
     size: 27549
@@ -95,34 +95,34 @@ arches:
     name: libeconf
     evr: 0.6.2-4.el10
     sourcerpm: libeconf-0.6.2-4.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/l/libgcc-14.2.1-7.el10.aarch64.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/l/libgcc-14.3.1-2.1.el10.aarch64.rpm
     repoid: rhel-10-for-aarch64-baseos-rpms
-    size: 123917
-    checksum: sha256:82d9a18ea38a3909882dd58dd48706558415a8fa2d48b0bc1726e4e4b156dfa6
+    size: 131565
+    checksum: sha256:c5b62563b17295211283be183e7dbf6e1a2dace932378f87c6bbd4e9c61b7bf8
     name: libgcc
-    evr: 14.2.1-7.el10
-    sourcerpm: gcc-14.2.1-7.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/l/libselinux-3.8-2.el10_0.aarch64.rpm
+    evr: 14.3.1-2.1.el10
+    sourcerpm: gcc-14.3.1-2.1.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/l/libselinux-3.9-1.el10.aarch64.rpm
     repoid: rhel-10-for-aarch64-baseos-rpms
-    size: 98723
-    checksum: sha256:5aee0daf8ba528ee176fd5c7bc4df64f088e7ed1ff1ca22c8eeee89ca9586db3
+    size: 98062
+    checksum: sha256:8bafdab6398fac0fd1e5d7ed8f5797d7c39cab39a5fd10ae11b3a496d0380b88
     name: libselinux
-    evr: 3.8-2.el10_0
-    sourcerpm: libselinux-3.8-2.el10_0.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/l/libsemanage-3.8.1-1.el10_0.aarch64.rpm
+    evr: 3.9-1.el10
+    sourcerpm: libselinux-3.9-1.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/l/libsemanage-3.9-1.el10.aarch64.rpm
     repoid: rhel-10-for-aarch64-baseos-rpms
-    size: 124983
-    checksum: sha256:b81f9eed0f91a17c510035d4a84b4f0d06c6f3c21088bd84b50bcb47e43835b5
+    size: 121634
+    checksum: sha256:56b58a15e0d9cb4a0782dee2949135540186427084659cd9c1a076dd58399dc4
     name: libsemanage
-    evr: 3.8.1-1.el10_0
-    sourcerpm: libsemanage-3.8.1-1.el10_0.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/l/libsepol-3.8-1.el10.aarch64.rpm
+    evr: 3.9-1.el10
+    sourcerpm: libsemanage-3.9-1.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/l/libsepol-3.9-1.el10.aarch64.rpm
     repoid: rhel-10-for-aarch64-baseos-rpms
-    size: 339397
-    checksum: sha256:5f35b586e68ce7bbd1736eda52e090d21bdfec7e8465cbf05f89a852e52eecb8
+    size: 339044
+    checksum: sha256:5e4ef9b0f89e26f34368366d950171c35db636f0b86f9aa001fda5210f9c90f5
     name: libsepol
-    evr: 3.8-1.el10
-    sourcerpm: libsepol-3.8-1.el10.src.rpm
+    evr: 3.9-1.el10
+    sourcerpm: libsepol-3.9-1.el10.src.rpm
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/l/libxcrypt-4.4.36-10.el10.aarch64.rpm
     repoid: rhel-10-for-aarch64-baseos-rpms
     size: 130795
@@ -144,13 +144,13 @@ arches:
     name: ncurses-libs
     evr: 6.4-14.20240127.el10
     sourcerpm: ncurses-6.4-14.20240127.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/p/pam-libs-1.6.1-7.el10.aarch64.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/p/pam-libs-1.6.1-8.el10.aarch64.rpm
     repoid: rhel-10-for-aarch64-baseos-rpms
-    size: 63279
-    checksum: sha256:d5e78269c97821406d10fe3a068a053266fc45ee714d0224e5538175c98bd392
+    size: 58890
+    checksum: sha256:f96fd7c57e5db28ac5e1773d2522f1d786edc13bdcc207b4d1d729802a1aac60
     name: pam-libs
-    evr: 1.6.1-7.el10
-    sourcerpm: pam-1.6.1-7.el10.src.rpm
+    evr: 1.6.1-8.el10
+    sourcerpm: pam-1.6.1-8.el10.src.rpm
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/p/pcre2-10.44-1.el10.3.aarch64.rpm
     repoid: rhel-10-for-aarch64-baseos-rpms
     size: 234650
@@ -165,41 +165,41 @@ arches:
     name: pcre2-syntax
     evr: 10.44-1.el10.3
     sourcerpm: pcre2-10.44-1.el10.3.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/r/redhat-release-10.0-30.el10.aarch64.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/r/redhat-release-10.1-18.el10.aarch64.rpm
     repoid: rhel-10-for-aarch64-baseos-rpms
-    size: 52284
-    checksum: sha256:9dfeaf23077a4e57b9b67057e04d2af9c244f03cc773fa08054f1b1127ee2b60
+    size: 61967
+    checksum: sha256:82ca4b2e241a01a9c31eb8d012bd6efe0128f9d45abd6797090c3825ddb50d04
     name: redhat-release
-    evr: 10.0-30.el10
-    sourcerpm: redhat-release-10.0-30.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/r/redhat-release-eula-10.0-30.el10.aarch64.rpm
+    evr: 10.1-18.el10
+    sourcerpm: redhat-release-10.1-18.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/r/redhat-release-eula-10.1-18.el10.aarch64.rpm
     repoid: rhel-10-for-aarch64-baseos-rpms
-    size: 15385
-    checksum: sha256:109fa3d07dc2e1cea809ff296464867cc902a7a43bf65f98e0a49715f130a2df
+    size: 15484
+    checksum: sha256:8179c6d9dc98c327cb1ab2f2abea22c3cfd924da53ec30943f0a81ab3f0def89
     name: redhat-release-eula
-    evr: 10.0-30.el10
-    sourcerpm: redhat-release-10.0-30.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/s/setup-2.14.5-4.el10.noarch.rpm
+    evr: 10.1-18.el10
+    sourcerpm: redhat-release-10.1-18.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/s/setup-2.14.5-7.el10.noarch.rpm
     repoid: rhel-10-for-aarch64-baseos-rpms
-    size: 161387
-    checksum: sha256:ba680ebee5408fbed4d0bf03d17fc29573ef0de6d51b71c72b7eb6e002562b2f
+    size: 156772
+    checksum: sha256:206fae73656417891f2c73570c1b3599044de31559e6060b62cc72e755c55ee4
     name: setup
-    evr: 2.14.5-4.el10
-    sourcerpm: setup-2.14.5-4.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/s/shadow-utils-4.15.0-5.el10.aarch64.rpm
+    evr: 2.14.5-7.el10
+    sourcerpm: setup-2.14.5-7.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/s/shadow-utils-4.15.0-8.el10.aarch64.rpm
     repoid: rhel-10-for-aarch64-baseos-rpms
-    size: 1417931
-    checksum: sha256:2fdd3267c9585a20aec8268f1347aa92e620726fbe4ddf6ced73420014f460d9
+    size: 1408442
+    checksum: sha256:70422e108ff0dda4699e1ca894e4df1d04d61828dc598e100a86e62d38595c77
     name: shadow-utils
-    evr: 2:4.15.0-5.el10
-    sourcerpm: shadow-utils-4.15.0-5.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/t/tzdata-2025b-1.el10.noarch.rpm
+    evr: 2:4.15.0-8.el10
+    sourcerpm: shadow-utils-4.15.0-8.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/Packages/t/tzdata-2025c-1.el10.noarch.rpm
     repoid: rhel-10-for-aarch64-baseos-rpms
-    size: 863215
-    checksum: sha256:dc0e9a9e6aaf4ffcd1a17eb363cb671d491c161f8199bb30430d34f189e2005f
+    size: 925672
+    checksum: sha256:8e550d18b34a76c5378320a9229cef97146e8391ae5d0e943164934755bd6c3d
     name: tzdata
-    evr: 2025b-1.el10
-    sourcerpm: tzdata-2025b-1.el10.src.rpm
+    evr: 2025c-1.el10
+    sourcerpm: tzdata-2025c-1.el10.src.rpm
   source:
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/a/acl-2.3.2-4.el10.src.rpm
     repoid: rhel-10-for-aarch64-baseos-source-rpms
@@ -213,12 +213,12 @@ arches:
     checksum: sha256:6cdf8680efdc37340b8c677e3382c996eb1596cf2f1ee1df87319a90be85bb88
     name: attr
     evr: 2.5.2-5.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/a/audit-4.0.3-1.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/a/audit-4.0.3-4.el10.src.rpm
     repoid: rhel-10-for-aarch64-baseos-source-rpms
-    size: 669055
-    checksum: sha256:5489f3f3848fc1b9d1a767c58b3f60c69962f38f80579e8efb5e91b802057e59
+    size: 679032
+    checksum: sha256:da3ffffe1ca116e14f6077affc2edddd01409b591601bf98eef7ee1d6590ad4a
     name: audit
-    evr: 4.0.3-1.el10
+    evr: 4.0.3-4.el10
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/b/basesystem-11-22.el10.src.rpm
     repoid: rhel-10-for-aarch64-baseos-source-rpms
     size: 16847
@@ -237,24 +237,24 @@ arches:
     checksum: sha256:1a222ad5c504f7a3313fa785fc4174f58f872d61f3a098e92e0de9dd11401fdc
     name: bzip2
     evr: 1.0.8-25.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/f/filesystem-3.18-16.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/f/filesystem-3.18-17.el10.src.rpm
     repoid: rhel-10-for-aarch64-baseos-source-rpms
-    size: 56583
-    checksum: sha256:c7c24c51527a94737945472af912142b16b72c4347832d84757b85e54e54746d
+    size: 56033
+    checksum: sha256:9dc2cd2b89600521b871884ac20822f7f0dd8bcc2d705b4fbfa0f2ecb07f9277
     name: filesystem
-    evr: 3.18-16.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/g/gcc-14.2.1-7.el10.src.rpm
+    evr: 3.18-17.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/g/gcc-14.3.1-2.1.el10.src.rpm
     repoid: rhel-10-for-aarch64-baseos-source-rpms
-    size: 93044983
-    checksum: sha256:db6c0f177b43534f8b89d8c9de1a797f87225d3dbc64d94a6be92ad4ea4cad29
+    size: 93160514
+    checksum: sha256:fc90092ff82ff4e4359b89035392894b014631c4cbba8a51ac8e4f602ca4b0b9
     name: gcc
-    evr: 14.2.1-7.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/g/glibc-2.39-46.el10_0.4.src.rpm
+    evr: 14.3.1-2.1.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/g/glibc-2.39-58.el10_1.7.src.rpm
     repoid: rhel-10-for-aarch64-baseos-source-rpms
-    size: 19613257
-    checksum: sha256:abf53bd496ecd2cdb98c7cc134cdf5a580b1d3efa683d61c1613a05538dc66b4
+    size: 20318950
+    checksum: sha256:a3719e5564a944ca286a359f7fc20e7befb5912fe4b3179d1aa0fd5f07bf1240
     name: glibc
-    evr: 2.39-46.el10_0.4
+    evr: 2.39-58.el10_1.7
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/l/libcap-ng-0.8.4-6.el10.src.rpm
     repoid: rhel-10-for-aarch64-baseos-source-rpms
     size: 488123
@@ -267,24 +267,24 @@ arches:
     checksum: sha256:6aa882f117f7904c66b4b04fdd0223bdcf67e690584bf32e03454eac77620b3d
     name: libeconf
     evr: 0.6.2-4.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/l/libselinux-3.8-2.el10_0.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/l/libselinux-3.9-1.el10.src.rpm
     repoid: rhel-10-for-aarch64-baseos-source-rpms
-    size: 399834
-    checksum: sha256:4ba518711b0ce564d734299f6761821f7be29ff95430ccb3874ab7840fbe5b68
+    size: 396507
+    checksum: sha256:d916feceaef2c522b93131d215b252fda0796d27867ca45d894d9f78be0303f8
     name: libselinux
-    evr: 3.8-2.el10_0
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/l/libsemanage-3.8.1-1.el10_0.src.rpm
+    evr: 3.9-1.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/l/libsemanage-3.9-1.el10.src.rpm
     repoid: rhel-10-for-aarch64-baseos-source-rpms
-    size: 309663
-    checksum: sha256:a900e9556d30950ea29d580e8e065bc902a3cc37fa89a80290f6e249eaa83d0f
+    size: 307884
+    checksum: sha256:b97568190bb8a61e16a049760eb5b438217f347b5c5ed9518e5e5e99eab96e02
     name: libsemanage
-    evr: 3.8.1-1.el10_0
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/l/libsepol-3.8-1.el10.src.rpm
+    evr: 3.9-1.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/l/libsepol-3.9-1.el10.src.rpm
     repoid: rhel-10-for-aarch64-baseos-source-rpms
-    size: 623887
-    checksum: sha256:e01b51d0618803ec0e0f8495cee44483728b1c43b0b2400984ac334192aeb2af
+    size: 623519
+    checksum: sha256:5bbe2865aa9df85421c81e9ed9a7755c62f3b21fdbcb4857608c946dfdeaa0f9
     name: libsepol
-    evr: 3.8-1.el10
+    evr: 3.9-1.el10
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/l/libxcrypt-4.4.36-10.el10.src.rpm
     repoid: rhel-10-for-aarch64-baseos-source-rpms
     size: 696641
@@ -297,52 +297,52 @@ arches:
     checksum: sha256:bcdb7e3f20dd71395f11564f495fce3ee29d4cfdf0de7d33c374d5899359ccb8
     name: ncurses
     evr: 6.4-14.20240127.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/p/pam-1.6.1-7.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/p/pam-1.6.1-8.el10.src.rpm
     repoid: rhel-10-for-aarch64-baseos-source-rpms
-    size: 1227973
-    checksum: sha256:09079a38c9aa37596deae75cacbc03fe2f9e4671f37af4928a56f039bf896bbd
+    size: 1237988
+    checksum: sha256:d708b0703fbe7e2eb6fffbf42b8117a58d970c7a0f7b73d09b78af20a16bb87b
     name: pam
-    evr: 1.6.1-7.el10
+    evr: 1.6.1-8.el10
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/p/pcre2-10.44-1.el10.3.src.rpm
     repoid: rhel-10-for-aarch64-baseos-source-rpms
     size: 1997003
     checksum: sha256:055a17c11624d3869c9d382ae9c1f5461c59480c26b9446bd6ea75686e87b9a8
     name: pcre2
     evr: 10.44-1.el10.3
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/r/redhat-release-10.0-30.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/r/redhat-release-10.1-18.el10.src.rpm
     repoid: rhel-10-for-aarch64-baseos-source-rpms
-    size: 100598
-    checksum: sha256:085dea8d6b454202f682435981fdcfa6eb3c572102a326ed1f575c5c2439198b
+    size: 116713
+    checksum: sha256:6ccc1069bf9eb4fad27a03a26165081d4fda835c5c4a54b3295e29e03d13c36b
     name: redhat-release
-    evr: 10.0-30.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/s/setup-2.14.5-4.el10.src.rpm
+    evr: 10.1-18.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/s/setup-2.14.5-7.el10.src.rpm
     repoid: rhel-10-for-aarch64-baseos-source-rpms
-    size: 252654
-    checksum: sha256:91f5bad388bfed9886e003271e3392e4844fa52876b2ea79e489cc679693c5cd
+    size: 252901
+    checksum: sha256:3cb2304fccb704447d3414339f703bf82e0c8adef6717d790e83a07a5e7685fe
     name: setup
-    evr: 2.14.5-4.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/s/shadow-utils-4.15.0-5.el10.src.rpm
+    evr: 2.14.5-7.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/s/shadow-utils-4.15.0-8.el10.src.rpm
     repoid: rhel-10-for-aarch64-baseos-source-rpms
-    size: 1917029
-    checksum: sha256:0856a2d59346aa1635409aa1198b00ea330e60041ebff419d53c9805fcf22f2c
+    size: 1913456
+    checksum: sha256:de2c630290f3ebd481d04ad7b00d908a09a851025d617329efddb53b081a4fc9
     name: shadow-utils
-    evr: 2:4.15.0-5.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/t/tzdata-2025b-1.el10.src.rpm
+    evr: 2:4.15.0-8.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/aarch64/baseos/source/SRPMS/Packages/t/tzdata-2025c-1.el10.src.rpm
     repoid: rhel-10-for-aarch64-baseos-source-rpms
-    size: 901378
-    checksum: sha256:1fe6209e677309bf2e276ee1f8d6a7ea18433223f259c89d2a4740bcfc0327bf
+    size: 914230
+    checksum: sha256:9dedddd9a31454e198b250ec1fb2f8a77c8470a48ec45b3cac44630fd25a3ea8
     name: tzdata
-    evr: 2025b-1.el10
+    evr: 2025c-1.el10
   module_metadata: []
 - arch: ppc64le
   packages:
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/a/audit-libs-4.0.3-1.el10.ppc64le.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/a/audit-libs-4.0.3-4.el10.ppc64le.rpm
     repoid: rhel-10-for-ppc64le-baseos-rpms
-    size: 147583
-    checksum: sha256:b7e89974a4105892ca45001df71f5082e5063b7671c797089ecb40367e93b7fb
+    size: 149162
+    checksum: sha256:d9e8444b4f1171ab1577f9ea1889a317652e13bba24a37ef2715a78c1eeeeb34
     name: audit-libs
-    evr: 4.0.3-1.el10
-    sourcerpm: audit-4.0.3-1.el10.src.rpm
+    evr: 4.0.3-4.el10
+    sourcerpm: audit-4.0.3-4.el10.src.rpm
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/b/basesystem-11-22.el10.noarch.rpm
     repoid: rhel-10-for-ppc64le-baseos-rpms
     size: 8521
@@ -364,41 +364,41 @@ arches:
     name: bzip2-libs
     evr: 1.0.8-25.el10
     sourcerpm: bzip2-1.0.8-25.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/f/filesystem-3.18-16.el10.ppc64le.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/f/filesystem-3.18-17.el10.ppc64le.rpm
     repoid: rhel-10-for-ppc64le-baseos-rpms
-    size: 4979126
-    checksum: sha256:e9bfaf5d01bb71f9b4561c2ab5aabb1904037250f42e5c1ee2011e44a8d09c68
+    size: 5009569
+    checksum: sha256:f36f649972eeca4e95c9651d775fa0444a1dbdc8736d981d9ce976f77eb3eec4
     name: filesystem
-    evr: 3.18-16.el10
-    sourcerpm: filesystem-3.18-16.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/g/glibc-2.39-46.el10_0.4.ppc64le.rpm
+    evr: 3.18-17.el10
+    sourcerpm: filesystem-3.18-17.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/g/glibc-2.39-58.el10_1.7.ppc64le.rpm
     repoid: rhel-10-for-ppc64le-baseos-rpms
-    size: 3033829
-    checksum: sha256:0aed6e9971e810fa192bc443438431a36ca38ac4a01e812f818518ed03e8ecc9
+    size: 3024272
+    checksum: sha256:ee2be023f23270639b340fcb840550ea85e432c82e517c4a2c51b934190ce342
     name: glibc
-    evr: 2.39-46.el10_0.4
-    sourcerpm: glibc-2.39-46.el10_0.4.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/g/glibc-common-2.39-46.el10_0.4.ppc64le.rpm
+    evr: 2.39-58.el10_1.7
+    sourcerpm: glibc-2.39-58.el10_1.7.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/g/glibc-common-2.39-58.el10_1.7.ppc64le.rpm
     repoid: rhel-10-for-ppc64le-baseos-rpms
-    size: 352252
-    checksum: sha256:b5542b13d1aeda1a7b7c04bfc338d9dda9eabbd5571dbb384fb053e05c8cdfea
+    size: 339619
+    checksum: sha256:09e2819b2dc0acf60b1f6ffdf4396cb682eda000f0471f93384c7046658e152c
     name: glibc-common
-    evr: 2.39-46.el10_0.4
-    sourcerpm: glibc-2.39-46.el10_0.4.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/g/glibc-gconv-extra-2.39-46.el10_0.4.ppc64le.rpm
+    evr: 2.39-58.el10_1.7
+    sourcerpm: glibc-2.39-58.el10_1.7.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/g/glibc-gconv-extra-2.39-58.el10_1.7.ppc64le.rpm
     repoid: rhel-10-for-ppc64le-baseos-rpms
-    size: 1842328
-    checksum: sha256:92a16f69a42645bd9fb837974ad052328d798a8ceedbcfdcaae5e49a5e1428c8
+    size: 1828272
+    checksum: sha256:a6f0fb1627d07eb05f9e135f212cd520414f72d13f4982bf0503c4270c722f43
     name: glibc-gconv-extra
-    evr: 2.39-46.el10_0.4
-    sourcerpm: glibc-2.39-46.el10_0.4.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/g/glibc-minimal-langpack-2.39-46.el10_0.4.ppc64le.rpm
+    evr: 2.39-58.el10_1.7
+    sourcerpm: glibc-2.39-58.el10_1.7.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/g/glibc-minimal-langpack-2.39-58.el10_1.7.ppc64le.rpm
     repoid: rhel-10-for-ppc64le-baseos-rpms
-    size: 43937
-    checksum: sha256:a0d3940ce06d222d244026ecabe3991136120ce9179f1d30ffbb220deafaed80
+    size: 31821
+    checksum: sha256:834f230a8db6749277f6a13c849d94fcaddf8ccc78ba89bde26013fd679e55a8
     name: glibc-minimal-langpack
-    evr: 2.39-46.el10_0.4
-    sourcerpm: glibc-2.39-46.el10_0.4.src.rpm
+    evr: 2.39-58.el10_1.7
+    sourcerpm: glibc-2.39-58.el10_1.7.src.rpm
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/l/libacl-2.3.2-4.el10.ppc64le.rpm
     repoid: rhel-10-for-ppc64le-baseos-rpms
     size: 29733
@@ -427,34 +427,34 @@ arches:
     name: libeconf
     evr: 0.6.2-4.el10
     sourcerpm: libeconf-0.6.2-4.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/l/libgcc-14.2.1-7.el10.ppc64le.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/l/libgcc-14.3.1-2.1.el10.ppc64le.rpm
     repoid: rhel-10-for-ppc64le-baseos-rpms
-    size: 101411
-    checksum: sha256:2a0836217b4465fac443ddf0fc0360132f82586fda5e70f19634fabce73e4f42
+    size: 108523
+    checksum: sha256:8b1fa51088c703338abb63bf91b6acde129f194ff946992f38a1de9ed81812d1
     name: libgcc
-    evr: 14.2.1-7.el10
-    sourcerpm: gcc-14.2.1-7.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/l/libselinux-3.8-2.el10_0.ppc64le.rpm
+    evr: 14.3.1-2.1.el10
+    sourcerpm: gcc-14.3.1-2.1.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/l/libselinux-3.9-1.el10.ppc64le.rpm
     repoid: rhel-10-for-ppc64le-baseos-rpms
-    size: 110828
-    checksum: sha256:8bd6a7cf232b0f82a7f812ce3e7433664aa20f89461f0f8840bcac63043f32c5
+    size: 110816
+    checksum: sha256:6d253bcd855aaf65cd08932a7b47bf79fcc01770e36e86281d067c7c544b7f96
     name: libselinux
-    evr: 3.8-2.el10_0
-    sourcerpm: libselinux-3.8-2.el10_0.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/l/libsemanage-3.8.1-1.el10_0.ppc64le.rpm
+    evr: 3.9-1.el10
+    sourcerpm: libselinux-3.9-1.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/l/libsemanage-3.9-1.el10.ppc64le.rpm
     repoid: rhel-10-for-ppc64le-baseos-rpms
-    size: 140381
-    checksum: sha256:2e899c57c524f66742ad08fa7a34c18ff546b49c5fa41b4fafe39e5e4a3cf243
+    size: 136982
+    checksum: sha256:215529186499d8a9fb9e8e406d4e5c0230f45138808fa30380b29b7c72f79322
     name: libsemanage
-    evr: 3.8.1-1.el10_0
-    sourcerpm: libsemanage-3.8.1-1.el10_0.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/l/libsepol-3.8-1.el10.ppc64le.rpm
+    evr: 3.9-1.el10
+    sourcerpm: libsemanage-3.9-1.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/l/libsepol-3.9-1.el10.ppc64le.rpm
     repoid: rhel-10-for-ppc64le-baseos-rpms
-    size: 385598
-    checksum: sha256:053a7a19a134cbfe93e3b5c37b38d0a70a5efcc2f530ad14e723e55c72d360e0
+    size: 384880
+    checksum: sha256:d01f976c786d78863d9b4cc895be6321ff73c5735215cd840e172f994f0e3fd6
     name: libsepol
-    evr: 3.8-1.el10
-    sourcerpm: libsepol-3.8-1.el10.src.rpm
+    evr: 3.9-1.el10
+    sourcerpm: libsepol-3.9-1.el10.src.rpm
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/l/libxcrypt-4.4.36-10.el10.ppc64le.rpm
     repoid: rhel-10-for-ppc64le-baseos-rpms
     size: 138025
@@ -476,13 +476,13 @@ arches:
     name: ncurses-libs
     evr: 6.4-14.20240127.el10
     sourcerpm: ncurses-6.4-14.20240127.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/p/pam-libs-1.6.1-7.el10.ppc64le.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/p/pam-libs-1.6.1-8.el10.ppc64le.rpm
     repoid: rhel-10-for-ppc64le-baseos-rpms
-    size: 69067
-    checksum: sha256:d9a2aad5fd2b703dcdeb34f9640a4ad77e6c96147516b36e4361605ca1b2cbd9
+    size: 64618
+    checksum: sha256:491a9dec328c1e79728703ee4080eb2bd7e5c82a08009c63706db8f1a6f6b091
     name: pam-libs
-    evr: 1.6.1-7.el10
-    sourcerpm: pam-1.6.1-7.el10.src.rpm
+    evr: 1.6.1-8.el10
+    sourcerpm: pam-1.6.1-8.el10.src.rpm
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/p/pcre2-10.44-1.el10.3.ppc64le.rpm
     repoid: rhel-10-for-ppc64le-baseos-rpms
     size: 260095
@@ -497,41 +497,41 @@ arches:
     name: pcre2-syntax
     evr: 10.44-1.el10.3
     sourcerpm: pcre2-10.44-1.el10.3.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/r/redhat-release-10.0-30.el10.ppc64le.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/r/redhat-release-10.1-18.el10.ppc64le.rpm
     repoid: rhel-10-for-ppc64le-baseos-rpms
-    size: 52275
-    checksum: sha256:a692028bbfa8fa39c342035266de1428048e089240c008434998919df4800a12
+    size: 61971
+    checksum: sha256:0e713df63d649d9fa67f30e10b62da73bdbcc3f4f787dcb714f651b2bbc22269
     name: redhat-release
-    evr: 10.0-30.el10
-    sourcerpm: redhat-release-10.0-30.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/r/redhat-release-eula-10.0-30.el10.ppc64le.rpm
+    evr: 10.1-18.el10
+    sourcerpm: redhat-release-10.1-18.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/r/redhat-release-eula-10.1-18.el10.ppc64le.rpm
     repoid: rhel-10-for-ppc64le-baseos-rpms
-    size: 15373
-    checksum: sha256:0f92924793ef5c6a690f19d4b7ef88e879f9e5faab62504f97c4261739fab68a
+    size: 15468
+    checksum: sha256:585753498f60e4302584e2570856b4a9e787233db18310aedc8cae9d1dce320c
     name: redhat-release-eula
-    evr: 10.0-30.el10
-    sourcerpm: redhat-release-10.0-30.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/s/setup-2.14.5-4.el10.noarch.rpm
+    evr: 10.1-18.el10
+    sourcerpm: redhat-release-10.1-18.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/s/setup-2.14.5-7.el10.noarch.rpm
     repoid: rhel-10-for-ppc64le-baseos-rpms
-    size: 161387
-    checksum: sha256:ba680ebee5408fbed4d0bf03d17fc29573ef0de6d51b71c72b7eb6e002562b2f
+    size: 156772
+    checksum: sha256:206fae73656417891f2c73570c1b3599044de31559e6060b62cc72e755c55ee4
     name: setup
-    evr: 2.14.5-4.el10
-    sourcerpm: setup-2.14.5-4.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/s/shadow-utils-4.15.0-5.el10.ppc64le.rpm
+    evr: 2.14.5-7.el10
+    sourcerpm: setup-2.14.5-7.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/s/shadow-utils-4.15.0-8.el10.ppc64le.rpm
     repoid: rhel-10-for-ppc64le-baseos-rpms
-    size: 1440946
-    checksum: sha256:0a5909cf540595c03533b223079f7adaaa3229b5a9629c6aaba251575d63bae7
+    size: 1432151
+    checksum: sha256:cf897c8b1e9348387cef8cbeaeb123de3bfebc87834dab609f257650d6a1bffb
     name: shadow-utils
-    evr: 2:4.15.0-5.el10
-    sourcerpm: shadow-utils-4.15.0-5.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/t/tzdata-2025b-1.el10.noarch.rpm
+    evr: 2:4.15.0-8.el10
+    sourcerpm: shadow-utils-4.15.0-8.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/os/Packages/t/tzdata-2025c-1.el10.noarch.rpm
     repoid: rhel-10-for-ppc64le-baseos-rpms
-    size: 863215
-    checksum: sha256:dc0e9a9e6aaf4ffcd1a17eb363cb671d491c161f8199bb30430d34f189e2005f
+    size: 925672
+    checksum: sha256:8e550d18b34a76c5378320a9229cef97146e8391ae5d0e943164934755bd6c3d
     name: tzdata
-    evr: 2025b-1.el10
-    sourcerpm: tzdata-2025b-1.el10.src.rpm
+    evr: 2025c-1.el10
+    sourcerpm: tzdata-2025c-1.el10.src.rpm
   source:
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/a/acl-2.3.2-4.el10.src.rpm
     repoid: rhel-10-for-ppc64le-baseos-source-rpms
@@ -545,12 +545,12 @@ arches:
     checksum: sha256:6cdf8680efdc37340b8c677e3382c996eb1596cf2f1ee1df87319a90be85bb88
     name: attr
     evr: 2.5.2-5.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/a/audit-4.0.3-1.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/a/audit-4.0.3-4.el10.src.rpm
     repoid: rhel-10-for-ppc64le-baseos-source-rpms
-    size: 669055
-    checksum: sha256:5489f3f3848fc1b9d1a767c58b3f60c69962f38f80579e8efb5e91b802057e59
+    size: 679032
+    checksum: sha256:da3ffffe1ca116e14f6077affc2edddd01409b591601bf98eef7ee1d6590ad4a
     name: audit
-    evr: 4.0.3-1.el10
+    evr: 4.0.3-4.el10
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/b/basesystem-11-22.el10.src.rpm
     repoid: rhel-10-for-ppc64le-baseos-source-rpms
     size: 16847
@@ -569,24 +569,24 @@ arches:
     checksum: sha256:1a222ad5c504f7a3313fa785fc4174f58f872d61f3a098e92e0de9dd11401fdc
     name: bzip2
     evr: 1.0.8-25.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/f/filesystem-3.18-16.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/f/filesystem-3.18-17.el10.src.rpm
     repoid: rhel-10-for-ppc64le-baseos-source-rpms
-    size: 56583
-    checksum: sha256:c7c24c51527a94737945472af912142b16b72c4347832d84757b85e54e54746d
+    size: 56033
+    checksum: sha256:9dc2cd2b89600521b871884ac20822f7f0dd8bcc2d705b4fbfa0f2ecb07f9277
     name: filesystem
-    evr: 3.18-16.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/g/gcc-14.2.1-7.el10.src.rpm
+    evr: 3.18-17.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/g/gcc-14.3.1-2.1.el10.src.rpm
     repoid: rhel-10-for-ppc64le-baseos-source-rpms
-    size: 93044983
-    checksum: sha256:db6c0f177b43534f8b89d8c9de1a797f87225d3dbc64d94a6be92ad4ea4cad29
+    size: 93160514
+    checksum: sha256:fc90092ff82ff4e4359b89035392894b014631c4cbba8a51ac8e4f602ca4b0b9
     name: gcc
-    evr: 14.2.1-7.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/g/glibc-2.39-46.el10_0.4.src.rpm
+    evr: 14.3.1-2.1.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/g/glibc-2.39-58.el10_1.7.src.rpm
     repoid: rhel-10-for-ppc64le-baseos-source-rpms
-    size: 19613257
-    checksum: sha256:abf53bd496ecd2cdb98c7cc134cdf5a580b1d3efa683d61c1613a05538dc66b4
+    size: 20318950
+    checksum: sha256:a3719e5564a944ca286a359f7fc20e7befb5912fe4b3179d1aa0fd5f07bf1240
     name: glibc
-    evr: 2.39-46.el10_0.4
+    evr: 2.39-58.el10_1.7
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/l/libcap-ng-0.8.4-6.el10.src.rpm
     repoid: rhel-10-for-ppc64le-baseos-source-rpms
     size: 488123
@@ -599,24 +599,24 @@ arches:
     checksum: sha256:6aa882f117f7904c66b4b04fdd0223bdcf67e690584bf32e03454eac77620b3d
     name: libeconf
     evr: 0.6.2-4.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/l/libselinux-3.8-2.el10_0.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/l/libselinux-3.9-1.el10.src.rpm
     repoid: rhel-10-for-ppc64le-baseos-source-rpms
-    size: 399834
-    checksum: sha256:4ba518711b0ce564d734299f6761821f7be29ff95430ccb3874ab7840fbe5b68
+    size: 396507
+    checksum: sha256:d916feceaef2c522b93131d215b252fda0796d27867ca45d894d9f78be0303f8
     name: libselinux
-    evr: 3.8-2.el10_0
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/l/libsemanage-3.8.1-1.el10_0.src.rpm
+    evr: 3.9-1.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/l/libsemanage-3.9-1.el10.src.rpm
     repoid: rhel-10-for-ppc64le-baseos-source-rpms
-    size: 309663
-    checksum: sha256:a900e9556d30950ea29d580e8e065bc902a3cc37fa89a80290f6e249eaa83d0f
+    size: 307884
+    checksum: sha256:b97568190bb8a61e16a049760eb5b438217f347b5c5ed9518e5e5e99eab96e02
     name: libsemanage
-    evr: 3.8.1-1.el10_0
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/l/libsepol-3.8-1.el10.src.rpm
+    evr: 3.9-1.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/l/libsepol-3.9-1.el10.src.rpm
     repoid: rhel-10-for-ppc64le-baseos-source-rpms
-    size: 623887
-    checksum: sha256:e01b51d0618803ec0e0f8495cee44483728b1c43b0b2400984ac334192aeb2af
+    size: 623519
+    checksum: sha256:5bbe2865aa9df85421c81e9ed9a7755c62f3b21fdbcb4857608c946dfdeaa0f9
     name: libsepol
-    evr: 3.8-1.el10
+    evr: 3.9-1.el10
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/l/libxcrypt-4.4.36-10.el10.src.rpm
     repoid: rhel-10-for-ppc64le-baseos-source-rpms
     size: 696641
@@ -629,52 +629,52 @@ arches:
     checksum: sha256:bcdb7e3f20dd71395f11564f495fce3ee29d4cfdf0de7d33c374d5899359ccb8
     name: ncurses
     evr: 6.4-14.20240127.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/p/pam-1.6.1-7.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/p/pam-1.6.1-8.el10.src.rpm
     repoid: rhel-10-for-ppc64le-baseos-source-rpms
-    size: 1227973
-    checksum: sha256:09079a38c9aa37596deae75cacbc03fe2f9e4671f37af4928a56f039bf896bbd
+    size: 1237988
+    checksum: sha256:d708b0703fbe7e2eb6fffbf42b8117a58d970c7a0f7b73d09b78af20a16bb87b
     name: pam
-    evr: 1.6.1-7.el10
+    evr: 1.6.1-8.el10
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/p/pcre2-10.44-1.el10.3.src.rpm
     repoid: rhel-10-for-ppc64le-baseos-source-rpms
     size: 1997003
     checksum: sha256:055a17c11624d3869c9d382ae9c1f5461c59480c26b9446bd6ea75686e87b9a8
     name: pcre2
     evr: 10.44-1.el10.3
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/r/redhat-release-10.0-30.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/r/redhat-release-10.1-18.el10.src.rpm
     repoid: rhel-10-for-ppc64le-baseos-source-rpms
-    size: 100598
-    checksum: sha256:085dea8d6b454202f682435981fdcfa6eb3c572102a326ed1f575c5c2439198b
+    size: 116713
+    checksum: sha256:6ccc1069bf9eb4fad27a03a26165081d4fda835c5c4a54b3295e29e03d13c36b
     name: redhat-release
-    evr: 10.0-30.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/s/setup-2.14.5-4.el10.src.rpm
+    evr: 10.1-18.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/s/setup-2.14.5-7.el10.src.rpm
     repoid: rhel-10-for-ppc64le-baseos-source-rpms
-    size: 252654
-    checksum: sha256:91f5bad388bfed9886e003271e3392e4844fa52876b2ea79e489cc679693c5cd
+    size: 252901
+    checksum: sha256:3cb2304fccb704447d3414339f703bf82e0c8adef6717d790e83a07a5e7685fe
     name: setup
-    evr: 2.14.5-4.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/s/shadow-utils-4.15.0-5.el10.src.rpm
+    evr: 2.14.5-7.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/s/shadow-utils-4.15.0-8.el10.src.rpm
     repoid: rhel-10-for-ppc64le-baseos-source-rpms
-    size: 1917029
-    checksum: sha256:0856a2d59346aa1635409aa1198b00ea330e60041ebff419d53c9805fcf22f2c
+    size: 1913456
+    checksum: sha256:de2c630290f3ebd481d04ad7b00d908a09a851025d617329efddb53b081a4fc9
     name: shadow-utils
-    evr: 2:4.15.0-5.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/t/tzdata-2025b-1.el10.src.rpm
+    evr: 2:4.15.0-8.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/ppc64le/baseos/source/SRPMS/Packages/t/tzdata-2025c-1.el10.src.rpm
     repoid: rhel-10-for-ppc64le-baseos-source-rpms
-    size: 901378
-    checksum: sha256:1fe6209e677309bf2e276ee1f8d6a7ea18433223f259c89d2a4740bcfc0327bf
+    size: 914230
+    checksum: sha256:9dedddd9a31454e198b250ec1fb2f8a77c8470a48ec45b3cac44630fd25a3ea8
     name: tzdata
-    evr: 2025b-1.el10
+    evr: 2025c-1.el10
   module_metadata: []
 - arch: s390x
   packages:
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/a/audit-libs-4.0.3-1.el10.s390x.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/a/audit-libs-4.0.3-4.el10.s390x.rpm
     repoid: rhel-10-for-s390x-baseos-rpms
-    size: 134034
-    checksum: sha256:f55dafb078aaf46c632ae030c104102411f6be10a231cb237432debdb24f2565
+    size: 135486
+    checksum: sha256:e4b8fdc590ff93e54497c711af34d5c0ad29a1fa884a535d191172045fa9e8f4
     name: audit-libs
-    evr: 4.0.3-1.el10
-    sourcerpm: audit-4.0.3-1.el10.src.rpm
+    evr: 4.0.3-4.el10
+    sourcerpm: audit-4.0.3-4.el10.src.rpm
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/b/basesystem-11-22.el10.noarch.rpm
     repoid: rhel-10-for-s390x-baseos-rpms
     size: 8521
@@ -696,41 +696,41 @@ arches:
     name: bzip2-libs
     evr: 1.0.8-25.el10
     sourcerpm: bzip2-1.0.8-25.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/f/filesystem-3.18-16.el10.s390x.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/f/filesystem-3.18-17.el10.s390x.rpm
     repoid: rhel-10-for-s390x-baseos-rpms
-    size: 4979114
-    checksum: sha256:8d4b39c83d4930c84fd387cedf03b543001975678b9314c54e8c412ea2045da9
+    size: 5009545
+    checksum: sha256:4c8780111f7a843c5427e1f809ded3b8c3481b35b26c1e1730126f495ce66573
     name: filesystem
-    evr: 3.18-16.el10
-    sourcerpm: filesystem-3.18-16.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/g/glibc-2.39-46.el10_0.4.s390x.rpm
+    evr: 3.18-17.el10
+    sourcerpm: filesystem-3.18-17.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/g/glibc-2.39-58.el10_1.7.s390x.rpm
     repoid: rhel-10-for-s390x-baseos-rpms
-    size: 1909137
-    checksum: sha256:15e5fc0fdd40bc949f1ae2fc3a750fb5fee218fb8d29e09549b1c01eac7ca52e
+    size: 1902589
+    checksum: sha256:4f69cbebe4200e8f5bf27ff736f3c1944fe639b479ba66015ba04d2df7400e8d
     name: glibc
-    evr: 2.39-46.el10_0.4
-    sourcerpm: glibc-2.39-46.el10_0.4.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/g/glibc-common-2.39-46.el10_0.4.s390x.rpm
+    evr: 2.39-58.el10_1.7
+    sourcerpm: glibc-2.39-58.el10_1.7.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/g/glibc-common-2.39-58.el10_1.7.s390x.rpm
     repoid: rhel-10-for-s390x-baseos-rpms
-    size: 358723
-    checksum: sha256:75f058932508efbc2699615809af293e08e6b6097dd5b1e430d71782252e2415
+    size: 347243
+    checksum: sha256:0305163c32ad2e6911d406fc183436ecbccccd84d1d1157c4de2cdec4cf55b70
     name: glibc-common
-    evr: 2.39-46.el10_0.4
-    sourcerpm: glibc-2.39-46.el10_0.4.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/g/glibc-gconv-extra-2.39-46.el10_0.4.s390x.rpm
+    evr: 2.39-58.el10_1.7
+    sourcerpm: glibc-2.39-58.el10_1.7.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/g/glibc-gconv-extra-2.39-58.el10_1.7.s390x.rpm
     repoid: rhel-10-for-s390x-baseos-rpms
-    size: 1794730
-    checksum: sha256:b281fd3e4414ab83b1ef92f17fdf50c841b0a949de31f355430ff3ebae333241
+    size: 1786096
+    checksum: sha256:d041fd0909faf662bb4b831c5b0199bdeb0e047c179174b5f0f6b0589a92f9a4
     name: glibc-gconv-extra
-    evr: 2.39-46.el10_0.4
-    sourcerpm: glibc-2.39-46.el10_0.4.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/g/glibc-minimal-langpack-2.39-46.el10_0.4.s390x.rpm
+    evr: 2.39-58.el10_1.7
+    sourcerpm: glibc-2.39-58.el10_1.7.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/g/glibc-minimal-langpack-2.39-58.el10_1.7.s390x.rpm
     repoid: rhel-10-for-s390x-baseos-rpms
-    size: 43925
-    checksum: sha256:3eeeca1c705a59f46172dc038069b64126ec49d908fb00bbe238b20f6a118d5e
+    size: 31805
+    checksum: sha256:66873012451a6bced66394ef9efee02f80d67b5774d1b4bc639c60f1d9536279
     name: glibc-minimal-langpack
-    evr: 2.39-46.el10_0.4
-    sourcerpm: glibc-2.39-46.el10_0.4.src.rpm
+    evr: 2.39-58.el10_1.7
+    sourcerpm: glibc-2.39-58.el10_1.7.src.rpm
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/l/libacl-2.3.2-4.el10.s390x.rpm
     repoid: rhel-10-for-s390x-baseos-rpms
     size: 28269
@@ -759,34 +759,34 @@ arches:
     name: libeconf
     evr: 0.6.2-4.el10
     sourcerpm: libeconf-0.6.2-4.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/l/libgcc-14.2.1-7.el10.s390x.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/l/libgcc-14.3.1-2.1.el10.s390x.rpm
     repoid: rhel-10-for-s390x-baseos-rpms
-    size: 97837
-    checksum: sha256:460c4b8452211baa3d30fe233598cdacaf63c7260f5ca3b00bc037e02afa84cd
+    size: 104423
+    checksum: sha256:fcc2eae9605fb66c234d06e9efe06338f61eb5858cbc471a5ff9b9650c09b9eb
     name: libgcc
-    evr: 14.2.1-7.el10
-    sourcerpm: gcc-14.2.1-7.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/l/libselinux-3.8-2.el10_0.s390x.rpm
+    evr: 14.3.1-2.1.el10
+    sourcerpm: gcc-14.3.1-2.1.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/l/libselinux-3.9-1.el10.s390x.rpm
     repoid: rhel-10-for-s390x-baseos-rpms
-    size: 103926
-    checksum: sha256:49bd0041c3ebb637a84ce3bffa59547e3fe78b08b22e232610fce6703e4f284b
+    size: 103300
+    checksum: sha256:48f3e75ed7fd2ee840f644ee1cabcc685136af3d1cd812ff33ba2ea2e05cba5f
     name: libselinux
-    evr: 3.8-2.el10_0
-    sourcerpm: libselinux-3.8-2.el10_0.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/l/libsemanage-3.8.1-1.el10_0.s390x.rpm
+    evr: 3.9-1.el10
+    sourcerpm: libselinux-3.9-1.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/l/libsemanage-3.9-1.el10.s390x.rpm
     repoid: rhel-10-for-s390x-baseos-rpms
-    size: 130442
-    checksum: sha256:38cd064c52cfa3124c83b5440c941d2d3ce231563a7a1e3cef76a72a207a15d4
+    size: 126734
+    checksum: sha256:f1a58985a2bf6cbbec51ca2b6c0cff4e079232e6d09e89a05caaa95d30e9eef2
     name: libsemanage
-    evr: 3.8.1-1.el10_0
-    sourcerpm: libsemanage-3.8.1-1.el10_0.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/l/libsepol-3.8-1.el10.s390x.rpm
+    evr: 3.9-1.el10
+    sourcerpm: libsemanage-3.9-1.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/l/libsepol-3.9-1.el10.s390x.rpm
     repoid: rhel-10-for-s390x-baseos-rpms
-    size: 363286
-    checksum: sha256:c4d04f746db35511e4889bc534e6dad477ba9e4baa108690c7bb59c889d7221f
+    size: 362920
+    checksum: sha256:7e98d47d33ced679c6947b75837ef05e9a3908d08620746c61126553d0bfbdc6
     name: libsepol
-    evr: 3.8-1.el10
-    sourcerpm: libsepol-3.8-1.el10.src.rpm
+    evr: 3.9-1.el10
+    sourcerpm: libsepol-3.9-1.el10.src.rpm
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/l/libxcrypt-4.4.36-10.el10.s390x.rpm
     repoid: rhel-10-for-s390x-baseos-rpms
     size: 132147
@@ -808,13 +808,13 @@ arches:
     name: ncurses-libs
     evr: 6.4-14.20240127.el10
     sourcerpm: ncurses-6.4-14.20240127.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/p/pam-libs-1.6.1-7.el10.s390x.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/p/pam-libs-1.6.1-8.el10.s390x.rpm
     repoid: rhel-10-for-s390x-baseos-rpms
-    size: 64350
-    checksum: sha256:9d75e09a555d7b7e618256562a99e0a380bde7d3afd2af497ebb45850d9abde5
+    size: 60159
+    checksum: sha256:e64aff8150148c0c63cd9aa3cf5977cc628bc2f76c14c828b7b4171d469a697f
     name: pam-libs
-    evr: 1.6.1-7.el10
-    sourcerpm: pam-1.6.1-7.el10.src.rpm
+    evr: 1.6.1-8.el10
+    sourcerpm: pam-1.6.1-8.el10.src.rpm
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/p/pcre2-10.44-1.el10.3.s390x.rpm
     repoid: rhel-10-for-s390x-baseos-rpms
     size: 270997
@@ -829,41 +829,41 @@ arches:
     name: pcre2-syntax
     evr: 10.44-1.el10.3
     sourcerpm: pcre2-10.44-1.el10.3.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/r/redhat-release-10.0-30.el10.s390x.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/r/redhat-release-10.1-18.el10.s390x.rpm
     repoid: rhel-10-for-s390x-baseos-rpms
-    size: 52242
-    checksum: sha256:3755bd76519b7908be0e272513700b4eccaeb454fd3bcafec541295322d63f92
+    size: 61924
+    checksum: sha256:6fa5d7ddd1693f4b60b2bc390c6d6eb5d8756843d83d5c22ff6475dfa1e3082e
     name: redhat-release
-    evr: 10.0-30.el10
-    sourcerpm: redhat-release-10.0-30.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/r/redhat-release-eula-10.0-30.el10.s390x.rpm
+    evr: 10.1-18.el10
+    sourcerpm: redhat-release-10.1-18.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/r/redhat-release-eula-10.1-18.el10.s390x.rpm
     repoid: rhel-10-for-s390x-baseos-rpms
-    size: 15357
-    checksum: sha256:283c4112148bdd6dab9d014e3eed0c42d565f7c2a80825d5bad7a588ebae0ed8
+    size: 15456
+    checksum: sha256:45a31f06dfbb70115b15ea5fa9d4859b1c4124e24f52eaccec98496cb406fce6
     name: redhat-release-eula
-    evr: 10.0-30.el10
-    sourcerpm: redhat-release-10.0-30.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/s/setup-2.14.5-4.el10.noarch.rpm
+    evr: 10.1-18.el10
+    sourcerpm: redhat-release-10.1-18.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/s/setup-2.14.5-7.el10.noarch.rpm
     repoid: rhel-10-for-s390x-baseos-rpms
-    size: 161387
-    checksum: sha256:ba680ebee5408fbed4d0bf03d17fc29573ef0de6d51b71c72b7eb6e002562b2f
+    size: 156772
+    checksum: sha256:206fae73656417891f2c73570c1b3599044de31559e6060b62cc72e755c55ee4
     name: setup
-    evr: 2.14.5-4.el10
-    sourcerpm: setup-2.14.5-4.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/s/shadow-utils-4.15.0-5.el10.s390x.rpm
+    evr: 2.14.5-7.el10
+    sourcerpm: setup-2.14.5-7.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/s/shadow-utils-4.15.0-8.el10.s390x.rpm
     repoid: rhel-10-for-s390x-baseos-rpms
-    size: 1429121
-    checksum: sha256:3b82c8d0577036de5387b0722e8ba28fd3caa6990c853c70ef8088c01006e51e
+    size: 1420683
+    checksum: sha256:9483bcaca4306cbb6879bf49027d56f88f8db3b98057af5591a36410d5f03f23
     name: shadow-utils
-    evr: 2:4.15.0-5.el10
-    sourcerpm: shadow-utils-4.15.0-5.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/t/tzdata-2025b-1.el10.noarch.rpm
+    evr: 2:4.15.0-8.el10
+    sourcerpm: shadow-utils-4.15.0-8.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/os/Packages/t/tzdata-2025c-1.el10.noarch.rpm
     repoid: rhel-10-for-s390x-baseos-rpms
-    size: 863215
-    checksum: sha256:dc0e9a9e6aaf4ffcd1a17eb363cb671d491c161f8199bb30430d34f189e2005f
+    size: 925672
+    checksum: sha256:8e550d18b34a76c5378320a9229cef97146e8391ae5d0e943164934755bd6c3d
     name: tzdata
-    evr: 2025b-1.el10
-    sourcerpm: tzdata-2025b-1.el10.src.rpm
+    evr: 2025c-1.el10
+    sourcerpm: tzdata-2025c-1.el10.src.rpm
   source:
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/a/acl-2.3.2-4.el10.src.rpm
     repoid: rhel-10-for-s390x-baseos-source-rpms
@@ -877,12 +877,12 @@ arches:
     checksum: sha256:6cdf8680efdc37340b8c677e3382c996eb1596cf2f1ee1df87319a90be85bb88
     name: attr
     evr: 2.5.2-5.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/a/audit-4.0.3-1.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/a/audit-4.0.3-4.el10.src.rpm
     repoid: rhel-10-for-s390x-baseos-source-rpms
-    size: 669055
-    checksum: sha256:5489f3f3848fc1b9d1a767c58b3f60c69962f38f80579e8efb5e91b802057e59
+    size: 679032
+    checksum: sha256:da3ffffe1ca116e14f6077affc2edddd01409b591601bf98eef7ee1d6590ad4a
     name: audit
-    evr: 4.0.3-1.el10
+    evr: 4.0.3-4.el10
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/b/basesystem-11-22.el10.src.rpm
     repoid: rhel-10-for-s390x-baseos-source-rpms
     size: 16847
@@ -901,24 +901,24 @@ arches:
     checksum: sha256:1a222ad5c504f7a3313fa785fc4174f58f872d61f3a098e92e0de9dd11401fdc
     name: bzip2
     evr: 1.0.8-25.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/f/filesystem-3.18-16.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/f/filesystem-3.18-17.el10.src.rpm
     repoid: rhel-10-for-s390x-baseos-source-rpms
-    size: 56583
-    checksum: sha256:c7c24c51527a94737945472af912142b16b72c4347832d84757b85e54e54746d
+    size: 56033
+    checksum: sha256:9dc2cd2b89600521b871884ac20822f7f0dd8bcc2d705b4fbfa0f2ecb07f9277
     name: filesystem
-    evr: 3.18-16.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/g/gcc-14.2.1-7.el10.src.rpm
+    evr: 3.18-17.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/g/gcc-14.3.1-2.1.el10.src.rpm
     repoid: rhel-10-for-s390x-baseos-source-rpms
-    size: 93044983
-    checksum: sha256:db6c0f177b43534f8b89d8c9de1a797f87225d3dbc64d94a6be92ad4ea4cad29
+    size: 93160514
+    checksum: sha256:fc90092ff82ff4e4359b89035392894b014631c4cbba8a51ac8e4f602ca4b0b9
     name: gcc
-    evr: 14.2.1-7.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/g/glibc-2.39-46.el10_0.4.src.rpm
+    evr: 14.3.1-2.1.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/g/glibc-2.39-58.el10_1.7.src.rpm
     repoid: rhel-10-for-s390x-baseos-source-rpms
-    size: 19613257
-    checksum: sha256:abf53bd496ecd2cdb98c7cc134cdf5a580b1d3efa683d61c1613a05538dc66b4
+    size: 20318950
+    checksum: sha256:a3719e5564a944ca286a359f7fc20e7befb5912fe4b3179d1aa0fd5f07bf1240
     name: glibc
-    evr: 2.39-46.el10_0.4
+    evr: 2.39-58.el10_1.7
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/l/libcap-ng-0.8.4-6.el10.src.rpm
     repoid: rhel-10-for-s390x-baseos-source-rpms
     size: 488123
@@ -931,24 +931,24 @@ arches:
     checksum: sha256:6aa882f117f7904c66b4b04fdd0223bdcf67e690584bf32e03454eac77620b3d
     name: libeconf
     evr: 0.6.2-4.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/l/libselinux-3.8-2.el10_0.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/l/libselinux-3.9-1.el10.src.rpm
     repoid: rhel-10-for-s390x-baseos-source-rpms
-    size: 399834
-    checksum: sha256:4ba518711b0ce564d734299f6761821f7be29ff95430ccb3874ab7840fbe5b68
+    size: 396507
+    checksum: sha256:d916feceaef2c522b93131d215b252fda0796d27867ca45d894d9f78be0303f8
     name: libselinux
-    evr: 3.8-2.el10_0
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/l/libsemanage-3.8.1-1.el10_0.src.rpm
+    evr: 3.9-1.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/l/libsemanage-3.9-1.el10.src.rpm
     repoid: rhel-10-for-s390x-baseos-source-rpms
-    size: 309663
-    checksum: sha256:a900e9556d30950ea29d580e8e065bc902a3cc37fa89a80290f6e249eaa83d0f
+    size: 307884
+    checksum: sha256:b97568190bb8a61e16a049760eb5b438217f347b5c5ed9518e5e5e99eab96e02
     name: libsemanage
-    evr: 3.8.1-1.el10_0
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/l/libsepol-3.8-1.el10.src.rpm
+    evr: 3.9-1.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/l/libsepol-3.9-1.el10.src.rpm
     repoid: rhel-10-for-s390x-baseos-source-rpms
-    size: 623887
-    checksum: sha256:e01b51d0618803ec0e0f8495cee44483728b1c43b0b2400984ac334192aeb2af
+    size: 623519
+    checksum: sha256:5bbe2865aa9df85421c81e9ed9a7755c62f3b21fdbcb4857608c946dfdeaa0f9
     name: libsepol
-    evr: 3.8-1.el10
+    evr: 3.9-1.el10
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/l/libxcrypt-4.4.36-10.el10.src.rpm
     repoid: rhel-10-for-s390x-baseos-source-rpms
     size: 696641
@@ -961,52 +961,52 @@ arches:
     checksum: sha256:bcdb7e3f20dd71395f11564f495fce3ee29d4cfdf0de7d33c374d5899359ccb8
     name: ncurses
     evr: 6.4-14.20240127.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/p/pam-1.6.1-7.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/p/pam-1.6.1-8.el10.src.rpm
     repoid: rhel-10-for-s390x-baseos-source-rpms
-    size: 1227973
-    checksum: sha256:09079a38c9aa37596deae75cacbc03fe2f9e4671f37af4928a56f039bf896bbd
+    size: 1237988
+    checksum: sha256:d708b0703fbe7e2eb6fffbf42b8117a58d970c7a0f7b73d09b78af20a16bb87b
     name: pam
-    evr: 1.6.1-7.el10
+    evr: 1.6.1-8.el10
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/p/pcre2-10.44-1.el10.3.src.rpm
     repoid: rhel-10-for-s390x-baseos-source-rpms
     size: 1997003
     checksum: sha256:055a17c11624d3869c9d382ae9c1f5461c59480c26b9446bd6ea75686e87b9a8
     name: pcre2
     evr: 10.44-1.el10.3
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/r/redhat-release-10.0-30.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/r/redhat-release-10.1-18.el10.src.rpm
     repoid: rhel-10-for-s390x-baseos-source-rpms
-    size: 100598
-    checksum: sha256:085dea8d6b454202f682435981fdcfa6eb3c572102a326ed1f575c5c2439198b
+    size: 116713
+    checksum: sha256:6ccc1069bf9eb4fad27a03a26165081d4fda835c5c4a54b3295e29e03d13c36b
     name: redhat-release
-    evr: 10.0-30.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/s/setup-2.14.5-4.el10.src.rpm
+    evr: 10.1-18.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/s/setup-2.14.5-7.el10.src.rpm
     repoid: rhel-10-for-s390x-baseos-source-rpms
-    size: 252654
-    checksum: sha256:91f5bad388bfed9886e003271e3392e4844fa52876b2ea79e489cc679693c5cd
+    size: 252901
+    checksum: sha256:3cb2304fccb704447d3414339f703bf82e0c8adef6717d790e83a07a5e7685fe
     name: setup
-    evr: 2.14.5-4.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/s/shadow-utils-4.15.0-5.el10.src.rpm
+    evr: 2.14.5-7.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/s/shadow-utils-4.15.0-8.el10.src.rpm
     repoid: rhel-10-for-s390x-baseos-source-rpms
-    size: 1917029
-    checksum: sha256:0856a2d59346aa1635409aa1198b00ea330e60041ebff419d53c9805fcf22f2c
+    size: 1913456
+    checksum: sha256:de2c630290f3ebd481d04ad7b00d908a09a851025d617329efddb53b081a4fc9
     name: shadow-utils
-    evr: 2:4.15.0-5.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/t/tzdata-2025b-1.el10.src.rpm
+    evr: 2:4.15.0-8.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/s390x/baseos/source/SRPMS/Packages/t/tzdata-2025c-1.el10.src.rpm
     repoid: rhel-10-for-s390x-baseos-source-rpms
-    size: 901378
-    checksum: sha256:1fe6209e677309bf2e276ee1f8d6a7ea18433223f259c89d2a4740bcfc0327bf
+    size: 914230
+    checksum: sha256:9dedddd9a31454e198b250ec1fb2f8a77c8470a48ec45b3cac44630fd25a3ea8
     name: tzdata
-    evr: 2025b-1.el10
+    evr: 2025c-1.el10
   module_metadata: []
 - arch: x86_64
   packages:
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/a/audit-libs-4.0.3-1.el10.x86_64.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/a/audit-libs-4.0.3-4.el10.x86_64.rpm
     repoid: rhel-10-for-x86_64-baseos-rpms
-    size: 134405
-    checksum: sha256:23af63849ac033f9de0b4d434e3989acbcc6cf86776bd2c1a750f47ec9c6accf
+    size: 135825
+    checksum: sha256:1206563b3a505b0d361a69ce85b37a0dd0029f69961564c4c3f45ffcbe461973
     name: audit-libs
-    evr: 4.0.3-1.el10
-    sourcerpm: audit-4.0.3-1.el10.src.rpm
+    evr: 4.0.3-4.el10
+    sourcerpm: audit-4.0.3-4.el10.src.rpm
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/b/basesystem-11-22.el10.noarch.rpm
     repoid: rhel-10-for-x86_64-baseos-rpms
     size: 8521
@@ -1028,41 +1028,41 @@ arches:
     name: bzip2-libs
     evr: 1.0.8-25.el10
     sourcerpm: bzip2-1.0.8-25.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/f/filesystem-3.18-16.el10.x86_64.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/f/filesystem-3.18-17.el10.x86_64.rpm
     repoid: rhel-10-for-x86_64-baseos-rpms
-    size: 4979162
-    checksum: sha256:b3b23124f526426bd51dc3eeaf08826f948923cf0e97b57eead9b610fe9e42e8
+    size: 5009601
+    checksum: sha256:97a57519650f2122b30a51db9a858d977e866f7f6f2b439548cd5b89422fe821
     name: filesystem
-    evr: 3.18-16.el10
-    sourcerpm: filesystem-3.18-16.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/g/glibc-2.39-46.el10_0.4.x86_64.rpm
+    evr: 3.18-17.el10
+    sourcerpm: filesystem-3.18-17.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/g/glibc-2.39-58.el10_1.7.x86_64.rpm
     repoid: rhel-10-for-x86_64-baseos-rpms
-    size: 2206760
-    checksum: sha256:5d79f2a79fa32ad80520c40b76b7736a24a429b3a944a8dc5751a54786e82a6a
+    size: 2199426
+    checksum: sha256:9187086e796873c92a6d24abc17a2901a0f3a24f81ea87e87bc1d365cd385689
     name: glibc
-    evr: 2.39-46.el10_0.4
-    sourcerpm: glibc-2.39-46.el10_0.4.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/g/glibc-common-2.39-46.el10_0.4.x86_64.rpm
+    evr: 2.39-58.el10_1.7
+    sourcerpm: glibc-2.39-58.el10_1.7.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/g/glibc-common-2.39-58.el10_1.7.x86_64.rpm
     repoid: rhel-10-for-x86_64-baseos-rpms
-    size: 345457
-    checksum: sha256:ba1075197e0f43289f14ac30323150fec494621fbc38a0523f2c67ff699dc201
+    size: 333510
+    checksum: sha256:cac198ca1fe2e55ca70e06ccf9f753adb569dcb7c029b87fa4266dda326edb69
     name: glibc-common
-    evr: 2.39-46.el10_0.4
-    sourcerpm: glibc-2.39-46.el10_0.4.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/g/glibc-gconv-extra-2.39-46.el10_0.4.x86_64.rpm
+    evr: 2.39-58.el10_1.7
+    sourcerpm: glibc-2.39-58.el10_1.7.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/g/glibc-gconv-extra-2.39-58.el10_1.7.x86_64.rpm
     repoid: rhel-10-for-x86_64-baseos-rpms
-    size: 1758685
-    checksum: sha256:186ca3460a019ddfc0bed5460cc45a7834b248e25feb68efe61f8f508324a449
+    size: 1749959
+    checksum: sha256:b643d083c6459fff47d74311c4faa67a711a29ada39fb781448cffac90ea11ff
     name: glibc-gconv-extra
-    evr: 2.39-46.el10_0.4
-    sourcerpm: glibc-2.39-46.el10_0.4.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/g/glibc-minimal-langpack-2.39-46.el10_0.4.x86_64.rpm
+    evr: 2.39-58.el10_1.7
+    sourcerpm: glibc-2.39-58.el10_1.7.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/g/glibc-minimal-langpack-2.39-58.el10_1.7.x86_64.rpm
     repoid: rhel-10-for-x86_64-baseos-rpms
-    size: 43981
-    checksum: sha256:a8648b93366fbacef79c8bbfa54b1550a8e60bf585ddae9df693dab4cf01a49d
+    size: 31861
+    checksum: sha256:f3fdc8a8bff9f87d529d6ff8b0aa8c933e1fb9eb6277ba1bab4d8bac98ed2e1f
     name: glibc-minimal-langpack
-    evr: 2.39-46.el10_0.4
-    sourcerpm: glibc-2.39-46.el10_0.4.src.rpm
+    evr: 2.39-58.el10_1.7
+    sourcerpm: glibc-2.39-58.el10_1.7.src.rpm
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/l/libacl-2.3.2-4.el10.x86_64.rpm
     repoid: rhel-10-for-x86_64-baseos-rpms
     size: 27231
@@ -1091,34 +1091,34 @@ arches:
     name: libeconf
     evr: 0.6.2-4.el10
     sourcerpm: libeconf-0.6.2-4.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/l/libgcc-14.2.1-7.el10.x86_64.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/l/libgcc-14.3.1-2.1.el10.x86_64.rpm
     repoid: rhel-10-for-x86_64-baseos-rpms
-    size: 140770
-    checksum: sha256:bb86eaec9fe6771e06d7592c5953532eb3d1939e481f02c8077812ea8a6c9bfb
+    size: 148710
+    checksum: sha256:40fb773131c0b5f5e9d46c9eddca87315bb84660463b26a3bb5d37dbfaaae13b
     name: libgcc
-    evr: 14.2.1-7.el10
-    sourcerpm: gcc-14.2.1-7.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/l/libselinux-3.8-2.el10_0.x86_64.rpm
+    evr: 14.3.1-2.1.el10
+    sourcerpm: gcc-14.3.1-2.1.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/l/libselinux-3.9-1.el10.x86_64.rpm
     repoid: rhel-10-for-x86_64-baseos-rpms
-    size: 100161
-    checksum: sha256:151a5b15503d40ac6aa9c15a79045cd9a1570ae72cad778c0ab357bc608ff02e
+    size: 99621
+    checksum: sha256:f5778b432d5601e9eab9a54a36ca7835c5e1d374a75e207f458732fe959d19b2
     name: libselinux
-    evr: 3.8-2.el10_0
-    sourcerpm: libselinux-3.8-2.el10_0.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/l/libsemanage-3.8.1-1.el10_0.x86_64.rpm
+    evr: 3.9-1.el10
+    sourcerpm: libselinux-3.9-1.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/l/libsemanage-3.9-1.el10.x86_64.rpm
     repoid: rhel-10-for-x86_64-baseos-rpms
-    size: 128050
-    checksum: sha256:4dea9430617032c2e94c3876d9b20d1a23aafd7a8e92ad46a350bf6c8e386f87
+    size: 124650
+    checksum: sha256:fa05a25b4e0e3803f7471c1be5ed8f37d09344a8d06374bf8792989de9c7d421
     name: libsemanage
-    evr: 3.8.1-1.el10_0
-    sourcerpm: libsemanage-3.8.1-1.el10_0.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/l/libsepol-3.8-1.el10.x86_64.rpm
+    evr: 3.9-1.el10
+    sourcerpm: libsemanage-3.9-1.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/l/libsepol-3.9-1.el10.x86_64.rpm
     repoid: rhel-10-for-x86_64-baseos-rpms
-    size: 357326
-    checksum: sha256:7338c67c19abbb6f0ae93af2ab6f775417f826557579b6bd500c4e361fe8ba39
+    size: 356305
+    checksum: sha256:f7048e4777a05e1f4edc50e69149c8850fbb0463b8c21b6e6519a1c3f523ad89
     name: libsepol
-    evr: 3.8-1.el10
-    sourcerpm: libsepol-3.8-1.el10.src.rpm
+    evr: 3.9-1.el10
+    sourcerpm: libsepol-3.9-1.el10.src.rpm
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/l/libxcrypt-4.4.36-10.el10.x86_64.rpm
     repoid: rhel-10-for-x86_64-baseos-rpms
     size: 127002
@@ -1140,13 +1140,13 @@ arches:
     name: ncurses-libs
     evr: 6.4-14.20240127.el10
     sourcerpm: ncurses-6.4-14.20240127.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/p/pam-libs-1.6.1-7.el10.x86_64.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/p/pam-libs-1.6.1-8.el10.x86_64.rpm
     repoid: rhel-10-for-x86_64-baseos-rpms
-    size: 63180
-    checksum: sha256:3c6ebad8c4ecffc91bd363ab18050b9dfc5131e23bc9aa44ba21ed2e8915fcd2
+    size: 59039
+    checksum: sha256:8afbaa7ed5d2cc9b74960805150ae283fdcbcab5587f12ebc5437f0b34127a8d
     name: pam-libs
-    evr: 1.6.1-7.el10
-    sourcerpm: pam-1.6.1-7.el10.src.rpm
+    evr: 1.6.1-8.el10
+    sourcerpm: pam-1.6.1-8.el10.src.rpm
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/p/pcre2-10.44-1.el10.3.x86_64.rpm
     repoid: rhel-10-for-x86_64-baseos-rpms
     size: 256297
@@ -1161,41 +1161,41 @@ arches:
     name: pcre2-syntax
     evr: 10.44-1.el10.3
     sourcerpm: pcre2-10.44-1.el10.3.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/r/redhat-release-10.0-30.el10.x86_64.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/r/redhat-release-10.1-18.el10.x86_64.rpm
     repoid: rhel-10-for-x86_64-baseos-rpms
-    size: 52343
-    checksum: sha256:8de77a3469dcfd79b60a850a44917c2cfc5170d19b64c2b58407c1a415b21e02
+    size: 61967
+    checksum: sha256:f19defae165ba4dbcd680d90396df27562f3d15f2521b5f3c78f90b8636c9dab
     name: redhat-release
-    evr: 10.0-30.el10
-    sourcerpm: redhat-release-10.0-30.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/r/redhat-release-eula-10.0-30.el10.x86_64.rpm
+    evr: 10.1-18.el10
+    sourcerpm: redhat-release-10.1-18.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/r/redhat-release-eula-10.1-18.el10.x86_64.rpm
     repoid: rhel-10-for-x86_64-baseos-rpms
-    size: 15409
-    checksum: sha256:49faa7ea3372f07ae3f173d9a06c94e496dc22d90baea2990135255d104fd4ae
+    size: 15508
+    checksum: sha256:0c3e1e691a74f4ed330d81e72007f09c643d70b00af90603975c0951ee21bc7d
     name: redhat-release-eula
-    evr: 10.0-30.el10
-    sourcerpm: redhat-release-10.0-30.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/s/setup-2.14.5-4.el10.noarch.rpm
+    evr: 10.1-18.el10
+    sourcerpm: redhat-release-10.1-18.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/s/setup-2.14.5-7.el10.noarch.rpm
     repoid: rhel-10-for-x86_64-baseos-rpms
-    size: 161387
-    checksum: sha256:ba680ebee5408fbed4d0bf03d17fc29573ef0de6d51b71c72b7eb6e002562b2f
+    size: 156772
+    checksum: sha256:206fae73656417891f2c73570c1b3599044de31559e6060b62cc72e755c55ee4
     name: setup
-    evr: 2.14.5-4.el10
-    sourcerpm: setup-2.14.5-4.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/s/shadow-utils-4.15.0-5.el10.x86_64.rpm
+    evr: 2.14.5-7.el10
+    sourcerpm: setup-2.14.5-7.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/s/shadow-utils-4.15.0-8.el10.x86_64.rpm
     repoid: rhel-10-for-x86_64-baseos-rpms
-    size: 1418965
-    checksum: sha256:382854dc41f456839178894efe7eafe66110d14808c2a02870c81dfedaee6303
+    size: 1411048
+    checksum: sha256:8d7e3846a08b620dbde011b15b8e058f579fccf3a1989c4321beaaf68631cc87
     name: shadow-utils
-    evr: 2:4.15.0-5.el10
-    sourcerpm: shadow-utils-4.15.0-5.el10.src.rpm
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/t/tzdata-2025b-1.el10.noarch.rpm
+    evr: 2:4.15.0-8.el10
+    sourcerpm: shadow-utils-4.15.0-8.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/Packages/t/tzdata-2025c-1.el10.noarch.rpm
     repoid: rhel-10-for-x86_64-baseos-rpms
-    size: 863215
-    checksum: sha256:dc0e9a9e6aaf4ffcd1a17eb363cb671d491c161f8199bb30430d34f189e2005f
+    size: 925672
+    checksum: sha256:8e550d18b34a76c5378320a9229cef97146e8391ae5d0e943164934755bd6c3d
     name: tzdata
-    evr: 2025b-1.el10
-    sourcerpm: tzdata-2025b-1.el10.src.rpm
+    evr: 2025c-1.el10
+    sourcerpm: tzdata-2025c-1.el10.src.rpm
   source:
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/a/acl-2.3.2-4.el10.src.rpm
     repoid: rhel-10-for-x86_64-baseos-source-rpms
@@ -1209,12 +1209,12 @@ arches:
     checksum: sha256:6cdf8680efdc37340b8c677e3382c996eb1596cf2f1ee1df87319a90be85bb88
     name: attr
     evr: 2.5.2-5.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/a/audit-4.0.3-1.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/a/audit-4.0.3-4.el10.src.rpm
     repoid: rhel-10-for-x86_64-baseos-source-rpms
-    size: 669055
-    checksum: sha256:5489f3f3848fc1b9d1a767c58b3f60c69962f38f80579e8efb5e91b802057e59
+    size: 679032
+    checksum: sha256:da3ffffe1ca116e14f6077affc2edddd01409b591601bf98eef7ee1d6590ad4a
     name: audit
-    evr: 4.0.3-1.el10
+    evr: 4.0.3-4.el10
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/b/basesystem-11-22.el10.src.rpm
     repoid: rhel-10-for-x86_64-baseos-source-rpms
     size: 16847
@@ -1233,24 +1233,24 @@ arches:
     checksum: sha256:1a222ad5c504f7a3313fa785fc4174f58f872d61f3a098e92e0de9dd11401fdc
     name: bzip2
     evr: 1.0.8-25.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/f/filesystem-3.18-16.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/f/filesystem-3.18-17.el10.src.rpm
     repoid: rhel-10-for-x86_64-baseos-source-rpms
-    size: 56583
-    checksum: sha256:c7c24c51527a94737945472af912142b16b72c4347832d84757b85e54e54746d
+    size: 56033
+    checksum: sha256:9dc2cd2b89600521b871884ac20822f7f0dd8bcc2d705b4fbfa0f2ecb07f9277
     name: filesystem
-    evr: 3.18-16.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/g/gcc-14.2.1-7.el10.src.rpm
+    evr: 3.18-17.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/g/gcc-14.3.1-2.1.el10.src.rpm
     repoid: rhel-10-for-x86_64-baseos-source-rpms
-    size: 93044983
-    checksum: sha256:db6c0f177b43534f8b89d8c9de1a797f87225d3dbc64d94a6be92ad4ea4cad29
+    size: 93160514
+    checksum: sha256:fc90092ff82ff4e4359b89035392894b014631c4cbba8a51ac8e4f602ca4b0b9
     name: gcc
-    evr: 14.2.1-7.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/g/glibc-2.39-46.el10_0.4.src.rpm
+    evr: 14.3.1-2.1.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/g/glibc-2.39-58.el10_1.7.src.rpm
     repoid: rhel-10-for-x86_64-baseos-source-rpms
-    size: 19613257
-    checksum: sha256:abf53bd496ecd2cdb98c7cc134cdf5a580b1d3efa683d61c1613a05538dc66b4
+    size: 20318950
+    checksum: sha256:a3719e5564a944ca286a359f7fc20e7befb5912fe4b3179d1aa0fd5f07bf1240
     name: glibc
-    evr: 2.39-46.el10_0.4
+    evr: 2.39-58.el10_1.7
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/l/libcap-ng-0.8.4-6.el10.src.rpm
     repoid: rhel-10-for-x86_64-baseos-source-rpms
     size: 488123
@@ -1263,24 +1263,24 @@ arches:
     checksum: sha256:6aa882f117f7904c66b4b04fdd0223bdcf67e690584bf32e03454eac77620b3d
     name: libeconf
     evr: 0.6.2-4.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/l/libselinux-3.8-2.el10_0.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/l/libselinux-3.9-1.el10.src.rpm
     repoid: rhel-10-for-x86_64-baseos-source-rpms
-    size: 399834
-    checksum: sha256:4ba518711b0ce564d734299f6761821f7be29ff95430ccb3874ab7840fbe5b68
+    size: 396507
+    checksum: sha256:d916feceaef2c522b93131d215b252fda0796d27867ca45d894d9f78be0303f8
     name: libselinux
-    evr: 3.8-2.el10_0
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/l/libsemanage-3.8.1-1.el10_0.src.rpm
+    evr: 3.9-1.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/l/libsemanage-3.9-1.el10.src.rpm
     repoid: rhel-10-for-x86_64-baseos-source-rpms
-    size: 309663
-    checksum: sha256:a900e9556d30950ea29d580e8e065bc902a3cc37fa89a80290f6e249eaa83d0f
+    size: 307884
+    checksum: sha256:b97568190bb8a61e16a049760eb5b438217f347b5c5ed9518e5e5e99eab96e02
     name: libsemanage
-    evr: 3.8.1-1.el10_0
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/l/libsepol-3.8-1.el10.src.rpm
+    evr: 3.9-1.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/l/libsepol-3.9-1.el10.src.rpm
     repoid: rhel-10-for-x86_64-baseos-source-rpms
-    size: 623887
-    checksum: sha256:e01b51d0618803ec0e0f8495cee44483728b1c43b0b2400984ac334192aeb2af
+    size: 623519
+    checksum: sha256:5bbe2865aa9df85421c81e9ed9a7755c62f3b21fdbcb4857608c946dfdeaa0f9
     name: libsepol
-    evr: 3.8-1.el10
+    evr: 3.9-1.el10
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/l/libxcrypt-4.4.36-10.el10.src.rpm
     repoid: rhel-10-for-x86_64-baseos-source-rpms
     size: 696641
@@ -1293,40 +1293,40 @@ arches:
     checksum: sha256:bcdb7e3f20dd71395f11564f495fce3ee29d4cfdf0de7d33c374d5899359ccb8
     name: ncurses
     evr: 6.4-14.20240127.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/p/pam-1.6.1-7.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/p/pam-1.6.1-8.el10.src.rpm
     repoid: rhel-10-for-x86_64-baseos-source-rpms
-    size: 1227973
-    checksum: sha256:09079a38c9aa37596deae75cacbc03fe2f9e4671f37af4928a56f039bf896bbd
+    size: 1237988
+    checksum: sha256:d708b0703fbe7e2eb6fffbf42b8117a58d970c7a0f7b73d09b78af20a16bb87b
     name: pam
-    evr: 1.6.1-7.el10
+    evr: 1.6.1-8.el10
   - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/p/pcre2-10.44-1.el10.3.src.rpm
     repoid: rhel-10-for-x86_64-baseos-source-rpms
     size: 1997003
     checksum: sha256:055a17c11624d3869c9d382ae9c1f5461c59480c26b9446bd6ea75686e87b9a8
     name: pcre2
     evr: 10.44-1.el10.3
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/r/redhat-release-10.0-30.el10.src.rpm
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/r/redhat-release-10.1-18.el10.src.rpm
     repoid: rhel-10-for-x86_64-baseos-source-rpms
-    size: 100598
-    checksum: sha256:085dea8d6b454202f682435981fdcfa6eb3c572102a326ed1f575c5c2439198b
+    size: 116713
+    checksum: sha256:6ccc1069bf9eb4fad27a03a26165081d4fda835c5c4a54b3295e29e03d13c36b
     name: redhat-release
-    evr: 10.0-30.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/s/setup-2.14.5-4.el10.src.rpm
+    evr: 10.1-18.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/s/setup-2.14.5-7.el10.src.rpm
     repoid: rhel-10-for-x86_64-baseos-source-rpms
-    size: 252654
-    checksum: sha256:91f5bad388bfed9886e003271e3392e4844fa52876b2ea79e489cc679693c5cd
+    size: 252901
+    checksum: sha256:3cb2304fccb704447d3414339f703bf82e0c8adef6717d790e83a07a5e7685fe
     name: setup
-    evr: 2.14.5-4.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/s/shadow-utils-4.15.0-5.el10.src.rpm
+    evr: 2.14.5-7.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/s/shadow-utils-4.15.0-8.el10.src.rpm
     repoid: rhel-10-for-x86_64-baseos-source-rpms
-    size: 1917029
-    checksum: sha256:0856a2d59346aa1635409aa1198b00ea330e60041ebff419d53c9805fcf22f2c
+    size: 1913456
+    checksum: sha256:de2c630290f3ebd481d04ad7b00d908a09a851025d617329efddb53b081a4fc9
     name: shadow-utils
-    evr: 2:4.15.0-5.el10
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/t/tzdata-2025b-1.el10.src.rpm
+    evr: 2:4.15.0-8.el10
+  - url: https://rhsm-pulp.corp.redhat.com/content/dist/rhel10/10/x86_64/baseos/source/SRPMS/Packages/t/tzdata-2025c-1.el10.src.rpm
     repoid: rhel-10-for-x86_64-baseos-source-rpms
-    size: 901378
-    checksum: sha256:1fe6209e677309bf2e276ee1f8d6a7ea18433223f259c89d2a4740bcfc0327bf
+    size: 914230
+    checksum: sha256:9dedddd9a31454e198b250ec1fb2f8a77c8470a48ec45b3cac44630fd25a3ea8
     name: tzdata
-    evr: 2025b-1.el10
+    evr: 2025c-1.el10
   module_metadata: []

--- a/update-rpm-lockfile
+++ b/update-rpm-lockfile
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# RHEL9 has the ability to handle modular metadata, required for using
+# rpm-lockfile-prototype.  Latest versions of Fedora are DNF5 which
+# removed the capability, although there's a 'dnf4' package that could
+# be used, presumably.
+CONTAINER_PULL=registry.access.redhat.com/ubi9:latest
+
+# relabel=shared lets us update the file on the host.
+podman run --volume $(pwd):/tmp:Z \
+	-it --rm $CONTAINER_PULL sh -c \
+	"cd /tmp && \
+	 dnf -y install python3-pip git && \
+	 pip3 install git+https://github.com/konflux-ci/rpm-lockfile-prototype && \
+	 rpm-lockfile-prototype rpms.in.yaml"


### PR DESCRIPTION
This PR does the following,
[1] Update the grafana version from 12.2.0 -> 12.3.1
[2] Update the container name
[3] Update the cpe tag
[4] Remove the manually added BUILD_DATE